### PR TITLE
Fix buffer clearing.

### DIFF
--- a/ExportMenu.php
+++ b/ExportMenu.php
@@ -568,7 +568,9 @@ class ExportMenu extends GridView
         if (!$this->stream) {
             $writer->save($this->filename . '.' . $config['extension']);
         } else {
-            ob_end_clean();
+            while (ob_get_level() > 1) {
+                ob_end_clean();
+            }
             $this->setHttpHeaders();
             $writer->save('php://output');
             Yii::$app->end();


### PR DESCRIPTION
If we want integrate this widget into another (f.e. GridView) we have issue with buffers: parent buffer would be prepended to generated result. To solve this problem we need clear all buffers except main.