### PR TITLE
Added stream output via temporary file

### DIFF
--- a/ExportMenu.php
+++ b/ExportMenu.php
@@ -277,7 +277,7 @@ class ExportMenu extends GridView
      * @var string the exported output file name. Defaults to 'grid-export';
      */
     public $filename;
-	
+
     /**
      * @var bool whether to stream output to the browser
      */
@@ -287,12 +287,12 @@ class ExportMenu extends GridView
      * @var string temporary directory path
      */
     public $tmpFolderPath = '@webroot/tmp/';
-	
+
 	/**
      * @var bool whether to stream output to the browser using temp file
      */
     public $emulateBuffer = false;
-	
+
     /**
      * @var array, the configuration of various messages that will be displayed at runtime:
      * - allowPopups: string, the message to be shown to disable browser popups for download. Defaults to `Disable any
@@ -600,19 +600,19 @@ class ExportMenu extends GridView
         if (!$this->stream) {
             $writer->save($this->filename . '.' . $config['extension']);
         } else {
-			$this->clearOutputBuffers();
+            $this->clearOutputBuffers();
             $this->setHttpHeaders();
-			
-			if($this->emulateBuffer && ($tpmFolderPath = \Yii::getAlias($this->tmpFolderPath)) && file_exists($tpmFolderPath) && is_writable($tpmFolderPath)) {
-				$filePath = $tpmFolderPath . $this->filename . '.' . $config['extension'];
-				$writer->save($filePath);
-				readfile($filePath);
-				@unlink($filePath);
-			} else {
-				$writer->save('php://output');
-			}
-			
-			$this->destroyPHPExcel();
+
+            if($this->emulateBuffer && ($tpmFolderPath = \Yii::getAlias($this->tmpFolderPath)) && file_exists($tpmFolderPath) && is_writable($tpmFolderPath)) {
+                $filePath = $tpmFolderPath . $this->filename . '.' . $config['extension'];
+                $writer->save($filePath);
+                readfile($filePath);
+                @unlink($filePath);
+            } else {
+                $writer->save('php://output');
+            }
+
+            $this->destroyPHPExcel();
             exit();
         }
     }


### PR DESCRIPTION
Useful when php output_buffer size is too small.
New properties:
tmpFolderPath - directory for save
emulateBuffer - whether to use this method