### PR TITLE
Created beforeContent and afterContent settings

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -1,6 +1,12 @@
 Change Log: `yii2-export`
 =========================
 
+## version 1.2.7
+
+**Date:** 30-Jun-2016
+
+- Created beforeContent and afterContent settings
+
 ## version 1.2.6
 
 **Date:** 02-Jun-2016

--- a/ExportMenu.php
+++ b/ExportMenu.php
@@ -4,7 +4,7 @@
  * @package   yii2-export
  * @author    Kartik Visweswaran <kartikv2@gmail.com>
  * @copyright Copyright &copy; Kartik Visweswaran, Krajee.com, 2015 - 2016
- * @version   1.2.6
+ * @version   1.2.7
  */
 
 namespace kartik\export;

--- a/ExportMenu.php
+++ b/ExportMenu.php
@@ -1625,7 +1625,7 @@ class ExportMenu extends GridView
         $sheet = $this->_objPHPExcelSheet;
         foreach ($this->contentAfter as $contentAfter){
             $sheet->setCellValue($colFirst . $row, $contentAfter['value'], true);
-            $sheet->getStyle($colFirst . $row)->applyFromArray(ArrayHelper::merge($this->_defaultStyleOptions, (isset($contentBefore['styleOptions']) ? ArrayHelper::getValue($contentBefore['styleOptions'], $this->_exportType, []) : [])));
+            $sheet->getStyle($colFirst . $row)->applyFromArray(ArrayHelper::merge($this->_defaultStyleOptions, (isset($contentAfter['styleOptions']) ? ArrayHelper::getValue($contentAfter['styleOptions'], $this->_exportType, []) : [])));
             $row += 1; 
         }                    
         for ($i = $afterContentBeginRow; $i < $row; $i++) {


### PR DESCRIPTION
- Allows for the creation of setting content before the exported grid and after the grid. 
- This is useful to be able to set things like a document title. It supports multiple row inserts and merges all of the beforeContent and afterContent values. 
- You can set styleOptions for each row as an optional value to style things like title
- All of these rows are merged to the full width of the table
- Removed 'caption' as a page title setting (ie. it is no longer possible to be set). Maybe this should be added back in if contentBefore is not set for backwards compatability
- Tested with footer set. 

Usage is as follows:

    ExportMenu::widget([
        ...
        'contentBefore'=>[
			[
				'value'=>'My Document Title',
				'styleOptions'=>[
			        ExportMenu::FORMAT_EXCEL => [
			            'font' => [
			                'bold' => true,
			                'size'=>15
			            ],						            
			        ],
			        ExportMenu::FORMAT_EXCEL_X => [
			            'font' => [
			                'bold' => true,						                
			                'size'=>15
			            ],						            
			        ],
			    ],
			],
			[
				'value'=>'Created on 30th June 2016',
				'styleOptions'=>[
			        ExportMenu::FORMAT_EXCEL => [
			            'font' => [						                
			                'size'=>14
			            ]						            
			        ],
			        ExportMenu::FORMAT_EXCEL_X => [
			            'font' => [						                
			                'size'=>14
			            ]
			        ],
			    ]
			],
			[
				'value'=>'' // for a blank row
			]						

		],
		'contentAfter'=>[
			[
				'value'=>'' // blank row
			],
			[
				'value'=>'End Document',
				'styleOptions'=>[
			        ExportMenu::FORMAT_EXCEL => [
			            'font' => [						                
			                'size'=>12
			            ],						            
			        ],
			        ExportMenu::FORMAT_EXCEL_X => [
			            'font' => [						                
			                'size'=>12
			            ],						            
			        ],
			    ],
			],
			[
				'value'=>'Created on 30th June 2016',
				'styleOptions'=>[
			        ExportMenu::FORMAT_EXCEL => [
			            'font' => [						                
			                'size'=>11
			            ]						            
			        ],
			        ExportMenu::FORMAT_EXCEL_X => [
			            'font' => [						                
			                'size'=>11
			            ]
			        ],
			    ]
			]
		],	