### PR TITLE
Clone pagination object before modifying it

### DIFF
--- a/ExportMenu.php
+++ b/ExportMenu.php
@@ -895,6 +895,7 @@ class ExportMenu extends GridView
     {
         $this->_provider = clone($this->dataProvider);
         if ($this->batchSize && $this->_provider->pagination) {
+            $this->_provider->pagination = clone($this->dataProvider->pagination);
             $this->_provider->pagination->pageSize = $this->batchSize;
         } else {
             $this->_provider->pagination = false;


### PR DESCRIPTION
## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-export/blob/master/CHANGE.md)):

- Do not modify original pagination object. Prevents altering of pagination in other widgets that are using the same data source.

When sharing the dataProvider with another widget, 
setting the pageSize parameter will modify the same
pagination object, and thus alter the pagination properties
of the other widgets.

## Related Issues

This is a followup to https://github.com/kartik-v/yii2-export/pull/76 .
