### PR TITLE
Empty export result when only first column is selected

### DIFF
--- a/ExportMenu.php
+++ b/ExportMenu.php
@@ -764,7 +764,7 @@ class ExportMenu extends GridView
             return;
         }
         $this->selectedColumns = array_keys($this->columnSelector);
-        if (empty($_POST[self::PARAM_EXPORT_COLS])) {
+        if (!isset($_POST[self::PARAM_EXPORT_COLS]) or !strlen($_POST[self::PARAM_EXPORT_COLS])) {
             return;
         }
         $this->selectedColumns = Json::decode($_POST[self::PARAM_EXPORT_COLS]);


### PR DESCRIPTION
## Scope
This pull request includes a

- [X] Bug fix

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-export/blob/master/CHANGE.md)):

- Fixes empty result set when only the first column is selected for export

## Related Issues
If this is related to an existing ticket, include a link to it as well.
Fixes #86