### PR TITLE
Fixed JSON DECODE in initSelectedColumns function

### DIFF
--- a/ExportMenu.php
+++ b/ExportMenu.php
@@ -767,7 +767,7 @@ class ExportMenu extends GridView
         if (!isset($_POST[self::PARAM_EXPORT_COLS]) or !strlen($_POST[self::PARAM_EXPORT_COLS])) {
             return;
         }
-        $this->selectedColumns = Json::decode($_POST[self::PARAM_EXPORT_COLS]);
+        $this->selectedColumns = explode(',', $_POST[self::PARAM_EXPORT_COLS]);
     }
 
     /**


### PR DESCRIPTION
## Scope

This pull request includes a
- [x] Bug fix
- [ ] New feature
- [ ] Translation
## Changes

The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-export/blob/master/CHANGE.md)):
## 
## 
## 
## Related Issues

If this is related to an existing ticket, include a link to it as well.
In the POST request param "export_columns" contains a string (list of id separated by comma) instead of a json encoded:

var_dump(export_columns);
string(97) "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35"

[LINE 770] $this->selectedColumns = Json::decode($_POST[self::PARAM_EXPORT_COLS]);

This line generates an error:

Invalid Parameter – yii\base\InvalidParamException
Syntax error.
