### PR TITLE
Fix for auto filter

### DIFF
--- a/ExportMenu.php
+++ b/ExportMenu.php
@@ -1174,7 +1174,7 @@ class ExportMenu extends GridView
 
         // Set autofilter on
         $this->_objPHPExcelSheet->setAutoFilter(
-            self::columnName(1) . $this->_beginRow . ':' . self::columnName($this->_endCol) . $this->_endRow
+            self::columnName(1) . $this->_beginRow . ':' . self::columnName($this->_endCol) . ($this->_beginRow + $this->_endRow)
         );
         return $this->_endRow;
     }


### PR DESCRIPTION
Fixed auto filter on wrong row when using multiple values in contentBefore

## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-export/blob/master/CHANGE.md)):

- Fixed auto filter position on wrong row when using multiple values in contentBefore

## Related Issues
#221 