### PR TITLE
Security: change default export path

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -1,6 +1,13 @@
 Change Log: `yii2-export`
 =========================
 
+## version 1.3 - to be released
+
+**Date:** 17-Jan-2018
+
+- Security: Do not use @webroot/runtime/export as default export directory because
+  this folder is available to the public! It was set to @app/runtime/export now.
+
 ## version 1.2.8
 
 **Date:** 19-Nov-2017

--- a/ExportMenu.php
+++ b/ExportMenu.php
@@ -328,10 +328,10 @@ class ExportMenu extends GridView
     public $filename;
 
     /**
-     * @var string the folder to save the exported file. Defaults to '@webroot/runtime/tmp/'. If the specified folder
+     * @var string the folder to save the exported file. Defaults to '@app/runtime/export/'. If the specified folder
      * does not exist, it will be attempted to be created or an exception will be thrown.
      */
-    public $folder = '@webroot/runtime/export';
+    public $folder = '@app/runtime/export';
 
     /**
      * @var string the web accessible path for the saved file location. This property will be parsed only if [[stream]]


### PR DESCRIPTION
Do not use webroot/runtime/export as default export directory because
this folder is available to the public! It was set to app/runtime/export now.
