### PR TITLE
Add new feature: direct download, supplement sheet, data validation

### DIFF
--- a/ExportMenu.php
+++ b/ExportMenu.php
@@ -561,6 +561,11 @@ class ExportMenu extends GridView
      */
     public $dataValidation = null;
         
+    /**
+     * @var bool direct export without $_POST. Use in conjunction with exportTYpe
+     */
+    public $triggerDownload = false;
+    
    /**
      * @var string translation message file category name for i18n
      */
@@ -573,8 +578,10 @@ class ExportMenu extends GridView
 
     /**
      * @var string the data output format type. Defaults to `ExportMenu::FORMAT_EXCEL_X`.
+     * edit: set this to public, so we can use 'direct export' feature. Should be change
+     * to $exportType as it is now not protected type, but public.
      */
-    protected $_exportType = self::FORMAT_EXCEL_X;
+    public $_exportType = self::FORMAT_EXCEL_X;
 
     /**
      * @var array the default export configuration
@@ -699,7 +706,7 @@ class ExportMenu extends GridView
             if ($this->stream) {
                 Yii::$app->controller->layout = false;
             }
-            $this->_exportType = $_POST[self::PARAM_EXPORT_TYPE];
+            $this->_exportType = $_POST[self::PARAM_EXPORT_TYPE] ? $_POST[self::PARAM_EXPORT_TYPE] : $this->_exportType;
             $this->_columnSelectorEnabled = $_POST[self::PARAM_COLSEL_FLAG];
             $this->initSelectedColumns();
         }
@@ -724,7 +731,7 @@ class ExportMenu extends GridView
         $this->initColumnSelector();
         $this->setVisibleColumns();
         $this->initExport();
-        if (!$this->_triggerDownload) {
+        if (!$this->_triggerDownload && !$this->triggerDownload) {
             $this->registerAssets();
             echo $this->renderExportMenu();
             return;

--- a/ExportMenu.php
+++ b/ExportMenu.php
@@ -550,6 +550,11 @@ class ExportMenu extends GridView
     ];
 
     /**
+     * @var string sheet name. Default to 'Worksheet'
+     */
+    public $sheetName = 'Worksheet';
+        
+    /**
      * @var array create new supplement sheets. Required for data validation in excel. format:
      * 'supplementSheet' => ['city' => $citiesKeyValueArray], ...]
      */
@@ -767,7 +772,7 @@ class ExportMenu extends GridView
             $this->createSupplementSheet();
         }
 
-        $this->_objSpreadsheet->setActiveSheetIndex(0);
+        $this->_objSpreadsheet->setActiveSheetIndex(0)->setTitle($this->sheetName);
         $row = $this->generateFooter();
         $this->generateAfterContent($row);
         $writer = $this->_objWriter;

--- a/ExportMenu.php
+++ b/ExportMenu.php
@@ -2050,17 +2050,21 @@ class ExportMenu extends GridView
      * @throws \PhpOffice\PhpSpreadsheet\Exception
      */
     public function createSupplementSheet() {
-        $sheetIndex = 1;
-        foreach ($this->supplementSheet as $sheetName => $sheetData) {
-            ## SHEET INDEX AND NAME
-            $this->_objSpreadsheet->createSheet($sheetIndex);
-            $sheet = $this->_objSpreadsheet->setActiveSheetIndex($sheetIndex)->setTitle($sheetName);
-            $sheetIndex++;
+        if ($this->_exportType == self::FORMAT_EXCEL || $this->_exportType == self::FORMAT_EXCEL_X) {
+            $sheetIndex = 1;
+            foreach ($this->supplementSheet as $sheetName => $sheetData) {
+                ## SHEET INDEX AND NAME
+                $this->_objSpreadsheet->createSheet($sheetIndex);
+                $sheet = $this->_objSpreadsheet->setActiveSheetIndex($sheetIndex)->setTitle($sheetName);
+                $sheetIndex++;
 
-            ## GENERATE BODY
-            $index = 1;
-            foreach ($sheetData as $key => $value) {
-                $sheet->setCellValue('A' . $index, $key)->setCellValue('B' . $index++, $value);
+                ## GENERATE HEADER
+                $sheet->setCellValue('A1', 'Key')->setCellValue('B1', 'Value');
+                ## GENERATE BODY
+                $index = 2;
+                foreach ($sheetData as $key => $value) {
+                    $sheet->setCellValue('A' . $index, $key)->setCellValue('B' . $index++, $value);
+                }
             }
         }
     }
@@ -2074,18 +2078,20 @@ class ExportMenu extends GridView
      * @throws \PhpOffice\PhpSpreadsheet\Exception
      */
     public function setDataValidation($sheetName, $cell, $length) {
-        $objValidation = $this->_objSpreadsheet->getActiveSheet()->getCell($cell)->getDataValidation();
-        $objValidation->setType(DataValidation::TYPE_LIST);
-        $objValidation->setErrorStyle(DataValidation::STYLE_INFORMATION);
-        $objValidation->setAllowBlank(false);
-        $objValidation->setShowInputMessage(true);
-        $objValidation->setShowErrorMessage(true);
-        $objValidation->setShowDropDown(true);
-        $objValidation->setErrorTitle('Input error');
-        $objValidation->setError('Value is not in list.');
-        $objValidation->setPromptTitle('Pick from list');
-        $objValidation->setPrompt('Please pick a value from the drop-down list.');
-        $objValidation->setFormula1($sheetName . '!$B$1:$B$' . $length);  // Make sure to put the list items between " and "  !!!
+        if ($this->_exportType == self::FORMAT_EXCEL || $this->_exportType == self::FORMAT_EXCEL_X) {
+            $objValidation = $this->_objSpreadsheet->getActiveSheet()->getCell($cell)->getDataValidation();
+            $objValidation->setType(DataValidation::TYPE_LIST);
+            $objValidation->setErrorStyle(DataValidation::STYLE_INFORMATION);
+            $objValidation->setAllowBlank(false);
+            $objValidation->setShowInputMessage(true);
+            $objValidation->setShowErrorMessage(true);
+            $objValidation->setShowDropDown(true);
+            $objValidation->setErrorTitle('Input error');
+            $objValidation->setError('Value is not in list.');
+            $objValidation->setPromptTitle('Pick from list');
+            $objValidation->setPrompt('Please pick a value from the drop-down list.');
+            $objValidation->setFormula1($sheetName . '!$B$2:$B$' . $length);  // Make sure to put the list items between " and "  !!!
+        }
     }
 
 }

--- a/ExportMenu.php
+++ b/ExportMenu.php
@@ -2090,7 +2090,7 @@ class ExportMenu extends GridView
             $objValidation->setError('Value is not in list.');
             $objValidation->setPromptTitle('Pick from list');
             $objValidation->setPrompt('Please pick a value from the drop-down list.');
-            $objValidation->setFormula1($sheetName . '!$B$2:$B$' . $length);  // Make sure to put the list items between " and "  !!!
+            $objValidation->setFormula1($sheetName . '!$B$2:$B$' . ($length + 1));  // Make sure to put the list items between " and "  !!!
         }
     }
 


### PR DESCRIPTION
## Scope
This pull request includes

- [ ] New feature

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-export/blob/master/CHANGE.md)):

- add `public $triggerDownload` for people that want to use direct download.
- `$_exportType` become **public**. Compliments the use of `$triggerDownload`. So, we can direct-download with other type beside default (xlsx)
- `$supplementSheet` will generate other sheet that have 2 columns, usually the key (colA) and value (colB)
- `$dataValidation` will create data validation for excel. The table is obtained from `$supplementSheet` result.

## Example Code
```
ExportMenu::widget([
    'dataProvider' => $dataProvider,
    'columns' => $gridColumns,
    'filename' => $this->title,
    'hiddenColumns' => [0, 10],
    'noExportColumns' => [0, 10],
    'triggerDownload' => true,
    '_exportType' => ExportMenu::FORMAT_EXCEL_X,
    'enableFormatter' => false,
    'supplementSheet' => [
        'city' => $cities,
        'province' => $provinces,
        'tops' => $tops,
    ],
    'dropdownOptions' => [
        'label' => 'Export',
        'class' => 'btn btn-default'
    ],
    'dataValidation' => [
        'city' => ['F2' => count($cities)],    // F2 is the 1st city column cell
        'province' => ['G2' => count($provinces)],    // G2 is the 1st province column cell
    ],
]);
```