### PR TITLE
New feature request: add hidden input fields in form

### DIFF
--- a/ExportMenu.php
+++ b/ExportMenu.php
@@ -550,6 +550,11 @@ class ExportMenu extends GridView
     ];
 
     /**
+     * @var array with extra hidden input form parameters
+     */
+    public $hiddenInput = [];
+	
+    /**
      * @var string translation message file category name for i18n
      */
     protected $_msgCat = 'kvexport';
@@ -875,6 +880,7 @@ class ExportMenu extends GridView
                 'exportTypeParam' => self::PARAM_EXPORT_TYPE,
                 'exportColsParam' => self::PARAM_EXPORT_COLS,
                 'colselFlagParam' => self::PARAM_COLSEL_FLAG,
+                'hiddenInput' => $this->hiddenInput,
             ]
         );
         if ($this->asDropdown) {

--- a/views/_form.php
+++ b/views/_form.php
@@ -24,4 +24,11 @@ echo Html::hiddenInput($exportTypeParam, $exportType);
 echo Html::hiddenInput($exportRequestParam, 1);
 echo Html::hiddenInput($exportColsParam, '');
 echo Html::hiddenInput($colselFlagParam, $columnSelectorEnabled);
+if (isset($hiddenInput))
+{
+   foreach($hiddenInput as $hiddenInputItem)  
+   {
+     echo Html::hiddenInput($hiddenInputItem['name'], $hiddenInputItem['value']);
+   }
+}
 echo Html::endForm();


### PR DESCRIPTION
New feature request: add hidden input fields in form in order to be able to add extra data in post.

example usage:

    echo ExportMenu::widget( [
        'dataProvider' => $dataProvider,
        'columns'      => [
          [ 'label' => 'label field 1', 'attribute' => 'field1', ],
          [ 'label' => 'label field 2', 'attribute' => 'field2', ],
        ],
        'hiddenInput' => [
          [ 'name'=>'inputName1', 'value' => $inputValue1, ],
          [ 'name'=>'inputName2', 'value' => $inputValue2, ],
        ],
    ] );

Related issue:
https://github.com/kartik-v/yii2-export/issues/249