### PR TITLE
Fix file not found browser error for UTF-8 filename

### DIFF
--- a/src/ExportMenu.php
+++ b/src/ExportMenu.php
@@ -793,7 +793,7 @@ class ExportMenu extends GridView
                 "Invalid permissions to write to '{$this->folder}' as set in `ExportMenu::folder` property."
             );
         }
-        $file = self::slash($this->folder) . $this->filename . '.' . $config['extension'];
+        $file = self::slash($this->folder) . iconv("UTF-8", "ISO-8859-1//TRANSLIT", $this->filename) . '.' . $config['extension'];
         $writer->save($file);
         if ($this->stream) {
             $this->clearOutputBuffers();


### PR DESCRIPTION
For example: export configuration with filename setting veiksmų_ataskaita.xlsx will save temporary file as veiksmu_ataskaita.xlsx