### PR TITLE
Update ExportMenu.php

### DIFF
--- a/src/ExportMenu.php
+++ b/src/ExportMenu.php
@@ -4,7 +4,7 @@
  * @package   yii2-export
  * @author    Kartik Visweswaran <kartikv2@gmail.com>
  * @copyright Copyright &copy; Kartik Visweswaran, Krajee.com, 2015 - 2018
- * @version   1.3.6
+ * @version   1.3.9
  */
 
 namespace kartik\export;

--- a/src/ExportMenu.php
+++ b/src/ExportMenu.php
@@ -796,6 +796,7 @@ class ExportMenu extends GridView
         $filename = iconv("UTF-8", "ISO-8859-1//TRANSLIT", $this->filename);
         $file = self::slash($this->folder) . $filename . '.' . $config['extension'];
         $writer->save($file);
+        ob_end_clean();
         if ($this->stream) {
             $this->clearOutputBuffers();
             $this->setHttpHeaders();


### PR DESCRIPTION
Fixes excel file with wrong / garbage encoding characters.

This is fixed by adding the following line
line 798 + ob_end_clean();

ob_end_clean() is already in $this->clearOutputBuffers(); but calling it before $writer->save($file) instead of after fixes it.

## Scope
This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-export/blob/master/CHANGE.md)):

-
-
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.