### PR TITLE
fix the loss of the first page if batchSize

### DIFF
--- a/src/ExportMenu.php
+++ b/src/ExportMenu.php
@@ -941,6 +941,7 @@ class ExportMenu extends GridView
             /** @noinspection PhpUndefinedFieldInspection */
             $this->_provider->pagination = clone($this->dataProvider->pagination);
             $this->_provider->pagination->pageSize = $this->batchSize;
+            $this->_provider->refresh();
         } else {
             $this->_provider->pagination = false;
         }

--- a/src/ExportMenu.php
+++ b/src/ExportMenu.php
@@ -942,8 +942,10 @@ class ExportMenu extends GridView
             $this->_provider->pagination = clone($this->dataProvider->pagination);
             $this->_provider->pagination->pageSize = $this->batchSize;
             $this->_provider->refresh();
-            $this->_provider->pagination->page = null;                                            
-            \Yii::$app->request->setQueryParams([$this->_provider->pagination->pageParam => 1]);  
+            if (\Yii::$app->request->getBodyParam('exportFull_export')) {
+                $this->_provider->pagination->page = null;
+                \Yii::$app->request->setQueryParams([$this->_provider->pagination->pageParam => 1]);
+            } 
         } else {
             $this->_provider->pagination = false;
         }

--- a/src/ExportMenu.php
+++ b/src/ExportMenu.php
@@ -1305,6 +1305,9 @@ class ExportMenu extends GridView
         $this->findGroupedColumn();
         while (count($models) > 0) {
             $keys = $this->_provider->getKeys();
+            if ($this->_provider instanceof ArrayDataProvider) {
+                $models = array_values($models);                
+            }                                                   
             foreach ($models as $index => $model) {
                 $key = $keys[$index];
                 $this->generateRow($model, $key, $this->_endRow);

--- a/src/ExportMenu.php
+++ b/src/ExportMenu.php
@@ -942,6 +942,8 @@ class ExportMenu extends GridView
             $this->_provider->pagination = clone($this->dataProvider->pagination);
             $this->_provider->pagination->pageSize = $this->batchSize;
             $this->_provider->refresh();
+            $this->_provider->pagination->page = null;                                            
+            \Yii::$app->request->setQueryParams([$this->_provider->pagination->pageParam => 1]);  
         } else {
             $this->_provider->pagination = false;
         }


### PR DESCRIPTION
## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-export/blob/master/CHANGE.md)):

- Fix the loss of the first page if batchSize
-
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.

If use the batchSize parameter it redefine pagination pagesize. But in first (while it is not set yet) in https://github.com/kartik-v/yii2-export/blob/19483fdc69d427966ffb80c8ea5283c1be2036f9/src/ExportMenu.php#L1782 the default pagesize models are requested and stored up into _models (var cache), so without the $forcePrepare param we loosing first page 

![image](https://user-images.githubusercontent.com/12899080/60176957-63aa6e80-9820-11e9-9b31-3a088b8ea5ce.png)

Loss step:

![image](https://user-images.githubusercontent.com/12899080/60177178-e29fa700-9820-11e9-9941-efd9a49a594d.png)
