### PR TITLE
Fix cell content formatting

### DIFF
--- a/src/ExportMenu.php
+++ b/src/ExportMenu.php
@@ -1377,7 +1377,7 @@ class ExportMenu extends GridView
             } else {
                 $value = '';
             }
-            $format = ArrayHelper::remove($column->contentOptions, 'cellFormat', null);
+            $format = ArrayHelper::getValue($column->contentOptions, 'cellFormat', null);
             $cell = $this->setOutCellValue(
                 $this->_objWorksheet,
                 self::columnName($this->_endCol) . ($index + $this->_beginRow + 1),


### PR DESCRIPTION
Fix a bug when output has only first row formatted, If DataColumn has cellFormat key defined in contentOptions property.

## Scope
This pull request includes a

- [x ] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-export/blob/master/CHANGE.md)):

-
-
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.