### PR TITLE
Get export type function

### DIFF
--- a/src/ExportMenu.php
+++ b/src/ExportMenu.php
@@ -1252,6 +1252,16 @@ class ExportMenu extends GridView
     }
 
     /**
+     * Gets the currently selected export type
+     *
+     * @return string
+     */
+    public function getExportType()
+    {
+        return $this->_exportType;
+    }
+
+    /**
      * Gets the column header content
      *
      * @param DataColumn $col


### PR DESCRIPTION
Gets the currently selected export type lost from code

## Scope
This pull request includes a

- [X] Bug fix
- [X] New feature


## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-export/blob/master/CHANGE.md)):

- Get the currently selected export type