### PR TITLE
Void return added for PHPSpreadsheet save method

### DIFF
--- a/src/ExportWriterPdf.php
+++ b/src/ExportWriterPdf.php
@@ -50,7 +50,7 @@ class ExportWriterPdf extends Mpdf
      * @throws PhpSpreadsheetException
      * @throws \yii\base\InvalidConfigException
      */
-    public function save($pFilename)
+    public function save($pFilename): void
     {
         $fileHandle = parent::prepareForSave($pFilename);
 


### PR DESCRIPTION
#322 fix when downloading pdf file

## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-export/blob/master/CHANGE.md)):

- void return implemented
-
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.