### PR TITLE
Add catch error to avoid 'Closure object cannot have properties' issue

### DIFF
--- a/src/ExportMenu.php
+++ b/src/ExportMenu.php
@@ -1393,7 +1393,14 @@ class ExportMenu extends GridView
             if (is_callable($contentOptions)) {
                 $contentOptions = $contentOptions($model, $key, $index, $column);
             }
-            $format = ArrayHelper::getValue($contentOptions, 'cellFormat', null);
+
+            //20201026 Scott: To avoid 'Closure object cannot have properties' error 
+            try {
+                $format = ArrayHelper::getValue($column->contentOptions, 'cellFormat', null);
+            } catch (\Error $e) {
+                $format = null;
+            }
+            
             $cell = $this->setOutCellValue(
                 $this->_objWorksheet,
                 self::columnName($this->_endCol) . ($index + $this->_beginRow + 1),


### PR DESCRIPTION
My PHP still at v7.04
And Yii2 is upgrade to latest version:  2.0.38 several days ago.

In new Yii2 version, Dynagrid export full data function encounter 'Closure object cannot have properties' error, so add guard to protect/resolve issue.

//20201026 Scott: To avoid 'Closure object cannot have properties' error 
            try {
                $format = ArrayHelper::getValue($column->contentOptions, 'cellFormat', null);
            } catch (\Error $e) {
                $format = null;
            }

## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-export/blob/master/CHANGE.md)):

-
-
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.