### PR TITLE
Fix to send pdfConfig info to outputted PDF

### DIFF
--- a/src/ExportWriterPdf.php
+++ b/src/ExportWriterPdf.php
@@ -28,7 +28,7 @@ class ExportWriterPdf extends Mpdf
      * @var array kartik\mpdf\Pdf component configuration settings
      */
     public $pdfConfig = [];
-
+    
     /**
      * @inheritdoc
      */
@@ -38,7 +38,29 @@ class ExportWriterPdf extends Mpdf
             unset($config['tempDir']);
         }
         $config = array_replace_recursive($config, $this->pdfConfig);
+        
         $pdf = new Pdf($config);
-        return $pdf->getApi();
+        return $pdf;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function save($pFilename): void
+    {
+        $fileHandle = parent::prepareForSave($pFilename);
+
+        
+        //  Create PDF
+        $config = ['tempDir' => $this->tempDir . '/mpdf'];
+        $pdf = $this->createExternalWriterInstance($config);
+        
+        $pdf->cssInline = $this->generateStyles(false);
+        $html = $this->generateSheetData();
+        
+        //  Write to file
+        fwrite($fileHandle, $pdf->output($html, '', 'S'));
+
+        parent::restoreStateAfterSave();
     }
 }

--- a/src/ExportWriterPdf.php
+++ b/src/ExportWriterPdf.php
@@ -55,9 +55,9 @@ class ExportWriterPdf extends Mpdf
         $config = ['tempDir' => $this->tempDir . '/mpdf'];
         $pdf = $this->createExternalWriterInstance($config);
         
+        $this->spreadsheet->getActiveSheet()->getPageSetup()->setRowsToRepeatAtTopByStartAndEnd(1,1);
         $pdf->cssInline = $this->generateStyles(false);
-        $html = $this->generateSheetData();
-        
+        $html = str_replace("<div style='page: page0'>", '<div>', $this->generateSheetData());
         //  Write to file
         fwrite($fileHandle, $pdf->output($html, '', 'S'));
 


### PR DESCRIPTION
## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-export/blob/master/CHANGE.md)):

- Changed `createExternalWriterInstance` to return the `kartik\mpdf\Pdf` instance
- Added override of `save` function that uses `kartik\mpdf\Pdf::output` function to ensure config is used correctly

## Related Issues
#343 