### PR TITLE
Check for web request before accessing `post()`

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -6,6 +6,7 @@ Change Log: `yii2-export`
 **Date:** _under development_
 
 - (enh #355): Correct dropdown init for Bootstrap v5.x.
+- (enh #360): Check for web context before accessing `post()`
 
 ## version 1.4.2
 

--- a/src/ExportMenu.php
+++ b/src/ExportMenu.php
@@ -860,8 +860,13 @@ class ExportMenu extends GridView
         }
         $this->_columnSelectorEnabled = $this->showColumnSelector && $this->asDropdown;
         $request = Yii::$app->request;
-        $this->_triggerDownload = $request->post($this->exportRequestParam, $this->triggerDownload);
-        $this->_exportType = $request->post($this->exportTypeParam, $this->exportType);
+        if ($request instanceof \yii\web\Request) {
+          $this->_triggerDownload = $request->post($this->exportRequestParam, $this->triggerDownload);
+          $this->_exportType = $request->post($this->exportTypeParam, $this->exportType);
+        } else {
+            $this->_triggerDownload = $this->triggerDownload;
+            $this->_exportType = $this->exportType;
+        }
         if (!$this->stream) {
             $this->target = self::TARGET_SELF;
         }
@@ -869,7 +874,9 @@ class ExportMenu extends GridView
             if ($this->stream) {
                 Yii::$app->controller->layout = false;
             }
-            $this->_columnSelectorEnabled = $request->post($this->colSelFlagParam, $this->_columnSelectorEnabled);
+            $this->_columnSelectorEnabled = $request instanceof \yii\web\Request ?
+                $request->post($this->colSelFlagParam, $this->_columnSelectorEnabled) :
+                $this->_columnSelectorEnabled;
             $this->initSelectedColumns();
         }
         if ($this->dynagrid) {

--- a/src/ExportMenu.php
+++ b/src/ExportMenu.php
@@ -691,13 +691,13 @@ class ExportMenu extends GridView
     /**
      * @var string the data output format type. Defaults to `ExportMenu::FORMAT_EXCEL_X`.
      */
-    private $_exportType;
+    protected $_exportType;
 
     /**
      * @var boolean private flag that will use $_POST [[exportRequestParam]] setting if available or use the
      * [[triggerDownload]] setting
      */
-    private $_triggerDownload;
+    protected $_triggerDownload;
 
     /**
      * Appends slash to path if it does not exist


### PR DESCRIPTION
These small modifications allow the use of the extension in console
context, specifically using it in a background job.

## Scope
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-export/blob/master/CHANGE.md)):

- check for `Web` context in `initSettings` to allow using the extension from console

This change still require the caller to avoid using `run()` and partially rewrite it in their functions.