### PR TITLE
Update ExportMenu.php

### DIFF
--- a/src/ExportMenu.php
+++ b/src/ExportMenu.php
@@ -1410,7 +1410,7 @@ class ExportMenu extends GridView
             //20201026 Scott: To avoid 'Closure object cannot have properties' error 
             try {
                 $format = ArrayHelper::getValue($column->contentOptions, 'cellFormat');
-            } catch (Exception $e) {
+            } catch (\Throwable $e) {
                 $format = null;
             }
 


### PR DESCRIPTION
php 7+ throws Throwable if $column->contentOptions is closure. To prevent global framework Throwable catch - we have to put it here

## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-export/blob/master/CHANGE.md)):

-
-
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.