### PR TITLE
Introduce a custom delimiter option for the export config FORMAT_CSV.

### DIFF
--- a/src/ExportMenu.php
+++ b/src/ExportMenu.php
@@ -1153,6 +1153,12 @@ class ExportMenu extends GridView
             $delimiter = $this->getSetting('delimiter', "\t");
             $writer->setDelimiter($delimiter);
         }
+
+        if ($t === self::FORMAT_CSV) {
+            $delimiter = $this->getSetting('delimiter', ",");
+            $writer->setDelimiter($delimiter);
+        }
+
         if ($this->encoding === self::ENCODING_UTF8 && ($t === self::FORMAT_CSV || $t === self::FORMAT_TEXT)) {
             $writer->setUseBOM(true);
         }
@@ -1867,6 +1873,7 @@ class ExportMenu extends GridView
                 'mime' => 'application/csv',
                 'extension' => 'csv',
                 'writer' => self::FORMAT_CSV,
+                'delimiter' => ",",
             ],
             self::FORMAT_TEXT => [
                 'label' => Yii::t('kvexport', 'Text'),


### PR DESCRIPTION
Semicolon is used by default.

## Scope
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-export/blob/master/CHANGE.md)):

-
-
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.

[365](https://github.com/kartik-v/yii2-export/issues/365)