### PR TITLE
fixed: https://github.com/kartik-v/yii2-export/issues/378

### DIFF
--- a/src/ExportWriterPdf.php
+++ b/src/ExportWriterPdf.php
@@ -32,7 +32,7 @@ class ExportWriterPdf extends Mpdf
     /**
      * @inheritdoc
      */
-    protected function createExternalWriterInstance($config = [])
+    protected function createExternalWriterInstance(array $config) : \Mpdf\Mpdf
     {
         if (isset($config['tempDir'])) {
             unset($config['tempDir']);


### PR DESCRIPTION
## Scope
This pull request includes a

- [x ] Bug fix
- [ ] New feature
- [ ] Translation


PHP Compile Error – [yii\base\ErrorException](https://www.yiiframework.com/doc-2.0/yii-base-errorexception.html)
Declaration of kartik\export\ExportWriterPdf::createExternalWriterInstance($config = []) must be compatible with PhpOffice\PhpSpreadsheet\Writer\Pdf\Mpdf::createExternalWriterInstance(array $config): Mpdf\Mpdf


## Related Issues
If this is related to an existing ticket, include a link to it as well.
[https://github.com/kartik-v/yii2-export/issues/378](https://github.com/kartik-v/yii2-export/issues/378)