### PR TITLE
add php8 compatibility without BC (supports php5, 7, 8, 8.3, 8.4)

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -1,6 +1,11 @@
 Change Log: `yii2-export`
 =========================
 
+## version 1.5
+
+- (bug #378): satisfy input/return typehints
+- ensure php8 compatibility
+
 ## version 1.4.3
 
 **Date:** 25-Jul-2023

--- a/src/ExportMenu.php
+++ b/src/ExportMenu.php
@@ -1798,14 +1798,18 @@ class ExportMenu extends GridView
     /**
      * Fetches the column label
      *
-     * @param  integer  $key
+     * @param  integer|string  $key
      * @param  Column  $column
      *
      * @return string
      */
     protected function getColumnLabel($key, $column)
     {
-        $key++;
+        \Yii::error(print_r($key,true),__METHOD__);
+
+        if (is_int($key)) {
+            $key++;
+        }
         $label = Yii::t('kvexport', 'Column').' '.$key;
         if (isset($column->label)) {
             $label = $column->label;

--- a/src/ExportMenu.php
+++ b/src/ExportMenu.php
@@ -1805,8 +1805,6 @@ class ExportMenu extends GridView
      */
     protected function getColumnLabel($key, $column)
     {
-        \Yii::error(print_r($key,true),__METHOD__);
-
         if (is_int($key)) {
             $key++;
         }

--- a/src/ExportWriterPdf.php
+++ b/src/ExportWriterPdf.php
@@ -10,6 +10,7 @@ namespace kartik\export;
 
 use kartik\mpdf\Pdf;
 use PhpOffice\PhpSpreadsheet\Writer\Pdf\Mpdf;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 /**
  * Krajee custom PDF Writer library based on MPdf
@@ -17,29 +18,52 @@ use PhpOffice\PhpSpreadsheet\Writer\Pdf\Mpdf;
  * @author Kartik Visweswaran <kartikv2@gmail.com>
  * @since 1.0
  */
-class ExportWriterPdf extends Mpdf
-{
-    /**
-     * @var string the exported output file name. Defaults to 'grid-export';
-     */
-    public $filename = '';
-
-    /**
-     * @var array kartik\mpdf\Pdf component configuration settings
-     */
-    public $pdfConfig = [];
-
-    /**
-     * @inheritdoc
-     */
-    protected function createExternalWriterInstance($config = [])
+if (version_compare(PHP_VERSION, '8.0.0', '<')) {
+    class ExportWriterPdf extends Mpdf
     {
-        if (isset($config['tempDir'])) {
-            unset($config['tempDir']);
-        }
-        $config = array_replace_recursive($config, $this->pdfConfig);
-        $pdf = new Pdf($config);
+        /**
+         * @var string the exported output file name. Defaults to 'grid-export';
+         */
+        public $filename = '';
 
-        return $pdf->getApi();
+        /**
+         * @var array kartik\mpdf\Pdf component configuration settings
+         */
+        public $pdfConfig = [];
+
+        /**
+         * @inheritdoc
+         */
+        protected function createExternalWriterInstance($config = [])
+        {
+            if (isset($config['tempDir'])) {
+                unset($config['tempDir']);
+            }
+            $config = array_replace_recursive($config, $this->pdfConfig);
+            $pdf = new Pdf($config);
+
+            return $pdf->getApi();
+        }
     }
+} else {
+    class ExportWriterPdf extends Mpdf
+    {
+        public function __construct(
+            Spreadsheet $spreadsheet,
+            public string $filename = '',
+            public array $pdfConfig=[]
+        )  {
+            parent::__construct($spreadsheet);
+        }
+
+        protected function createExternalWriterInstance(array $config ): \Mpdf\Mpdf
+        {
+            unset($config['tempDir']);
+            $config = array_replace_recursive($config, $this->pdfConfig);
+            $pdf = new Pdf($config);
+
+            return $pdf->getApi();
+        }
+    }    
 }
+


### PR DESCRIPTION
## Scope
This pull request fixes #378 and ensures php8 compatibility.

## Changes
- (bug #378): satisfy input/return typehints
- ensure php8 compatibility

## Related Issues
#378 